### PR TITLE
fix for issue #142

### DIFF
--- a/src/main/java/com/orasi/utils/TestReporter.java
+++ b/src/main/java/com/orasi/utils/TestReporter.java
@@ -533,26 +533,30 @@ public class TestReporter {
     public static void logConsoleErrors(OrasiDriver driver) {
         // Only capture logs for chrome browser
         if (driver != null) {
-            if (driver.getDriverCapability().browserName().equalsIgnoreCase("chrome")) {
-                Reporter.log("<br/><b><font size = 4>Chrome Browser Console errors: </font></b><br/>");
-                LogEntries logs = driver.manage().logs().get("browser");
-                List<LogEntry> logList = logs.getAll();
-                String color = "red";
-                // Go through all the log entries, and only output the severe level errors (rest are most likely warnings)
-                boolean flag = false;
-                for (LogEntry entry : logList) {
-                    if (entry.getLevel() == Level.SEVERE) {
-                        Reporter.log(" <font size = 2 color=\"" + color + "\"><b> Level :: " + entry.getLevel().getName()
-                                + "</font></b><br />");
-                        Reporter.log(" <font size = 2 color=\"" + color + "\"><b> Message :: " + entry.getMessage()
-                                + "</font></b><br />");
-                        flag = true;
+            if (driver.getDriverCapability().browserName().equalsIgnoreCase("chrome")) { 
+    		    if (driver.getSessionId()!= null) {
+    		    	Reporter.log("<br/><b><font size = 4>Chrome Browser Console errors: </font></b><br/>");
+                    LogEntries logs = driver.manage().logs().get("browser");
+                    List<LogEntry> logList = logs.getAll();
+                    String color = "red";
+                    // Go through all the log entries, and only output the severe level errors (rest are most likely warnings)
+                    boolean flag = false;
+                    for (LogEntry entry : logList) {
+                        if (entry.getLevel() == Level.SEVERE) {
+                            Reporter.log(" <font size = 2 color=\"" + color + "\"><b> Level :: " + entry.getLevel().getName()
+                                    + "</font></b><br />");
+                            Reporter.log(" <font size = 2 color=\"" + color + "\"><b> Message :: " + entry.getMessage()
+                                    + "</font></b><br />");
+                            flag = true;
+                        }
                     }
-                }
 
-                if (!flag) {
-                    Reporter.log("NO ERRORS");
-                }
+                    if (!flag) {
+                        Reporter.log("NO ERRORS");
+                    }
+    		    } else {
+    		    	TestReporter.log("Driver session ID was null, could not log console errors");
+    		    }               
             }
         } else {
             TestReporter.log("Driver was null, could not capture console errors");

--- a/src/main/java/com/orasi/web/OrasiDriver.java
+++ b/src/main/java/com/orasi/web/OrasiDriver.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.safari.SafariDriver;
 
 import com.orasi.DriverType;
 import com.orasi.utils.Constants;
+import com.orasi.utils.JavaUtilities;
 import com.orasi.utils.TestReporter;
 import com.orasi.utils.dataHelpers.DataWarehouse;
 import com.orasi.web.debugging.Colors;
@@ -638,7 +639,11 @@ public class OrasiDriver implements WebDriver, TakesScreenshot {
      * @see https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/remote/SessionId.java
      */
     public String getSessionId() {
-        return getRemoteWebDriver().getSessionId().toString();
+    	if (JavaUtilities.isValid(getRemoteWebDriver().getSessionId())) {
+    		return getRemoteWebDriver().getSessionId().toString();
+    	} else {
+    		return null;
+    	}   	
     }
 
     /**

--- a/src/main/java/com/orasi/web/WebBaseTest.java
+++ b/src/main/java/com/orasi/web/WebBaseTest.java
@@ -434,7 +434,7 @@ public class WebBaseTest extends BaseTest {
         }
 
         // quit driver
-        DriverManager.getDriver().quit();
+        DriverManager.quitDriver();
     }
 
     /**

--- a/src/test/java/com/orasi/utils/TestTestReporter.java
+++ b/src/test/java/com/orasi/utils/TestTestReporter.java
@@ -11,6 +11,7 @@ import org.testng.ITestResult;
 import org.testng.Reporter;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.orasi.api.restServices.RestResponse;
@@ -23,18 +24,19 @@ import com.orasi.web.WebBaseTest;
 
 public class TestTestReporter extends WebBaseTest {
     OrasiDriver driver = null;
+    
+    @BeforeMethod()
+    public void setup() {
+    	setApplicationUnderTest("Test Site");
+        setPageURL("http://orasi.github.io/Chameleon/sites/unitTests/orasi/core/interfaces/listbox.html");
+    }
 
     @AfterClass
     public void cleanup() {
         TestReporter.setDebugLevel(0);
-        driver.quit();
+        //driver.quit();
     }
-
-    @Override
-    @AfterMethod(alwaysRun = true)
-    public void afterMethod(ITestResult testResults) {
-    }
-
+    
     @Test
     public void testAssertEquals() {
         String log = "testAssertEquals";
@@ -393,11 +395,19 @@ public class TestTestReporter extends WebBaseTest {
 
     @Test(dependsOnMethods = { "testLogConsoleLogsNoErrors" })
     public void testLogConsoleLogsWithErrors() {
+    	driver = testStart("console");
         TestReporter.setDebugLevel(2);
         String log = "Chrome Browser Console errors";
         driver.executeJavaScript("console.error('blah')");
         TestReporter.logConsoleErrors(driver);
         Assert.assertTrue(logHelper(Reporter.getOutput(), log));
+    }
+    
+    @Test()
+    public void testLogConsoleErrorSessionIDNull() {
+    	driver = testStart("console");
+    	driver.quit();
+    	TestReporter.logConsoleErrors(driver);
     }
 
     @Test

--- a/src/test/resources/sandbox.xml
+++ b/src/test/resources/sandbox.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Core-Regression" parallel="methods" thread-count="20">
-	<parameter name="browserUnderTest" value="html" />
+	<parameter name="browserUnderTest" value="chrome" />
 	<parameter name="environment" value="staging" />
 	<parameter name="runLocation" value="local" />
 	<parameter name="browserVersion" value="" />
 	<parameter name="operatingSystem" value="windows 10" />
  
-	<test name="Testbox Test" parallel="methods" thread-count="20">
+	<test name="Testbox Test" parallel="methods" thread-count="1">
 		<classes>
-			<class name="com.orasi.web.webelements.TestElement" />
+			<class name="com.orasi.utils.TestTestReporter" />
 		</classes>
 	</test>
 	


### PR DESCRIPTION
I added code for 2 related things in this pull request.

1. Added a check in the getSessionID() method to check if session ID is null before attempting to convert to string.  
2. In the method endTest(String testName, ITestResult, testResults) to use DriverManger.quitDriver()

Both so that if the driver crashes for some reason, it won't fail the test.  