### PR TITLE
Change Sleeper.sleep and all references to use seconds

### DIFF
--- a/src/main/java/com/orasi/utils/Constants.java
+++ b/src/main/java/com/orasi/utils/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
     public final static int ELEMENT_TIMEOUT = 3;
     public final static int PAGE_TIMEOUT = 10;
     public final static int MILLISECONDS_TO_POLL_FOR_ELEMENT = 250;
+    public final static int MAX_SLEEP_TIME = 600;
 
     /*
      * Test constants

--- a/src/main/java/com/orasi/utils/Sleeper.java
+++ b/src/main/java/com/orasi/utils/Sleeper.java
@@ -5,8 +5,8 @@ import static com.orasi.utils.Constants.MAX_SLEEP_TIME;
 
 public class Sleeper {
     public static void sleep(double seconds) {
-    	if (seconds>MAX_SLEEP_TIME) {
-    		throw new RuntimeException("Sleep time exceeds 600 seconds.");
+    	if (seconds>=MAX_SLEEP_TIME) {
+    		throw new AutomationException("Sleep time exceeds "+MAX_SLEEP_TIME+" seconds.");
     	}
         TestReporter.logTrace("Sleeping for [ " + seconds + " ] seconds");
         StopWatch stopwatch = new StopWatch();

--- a/src/main/java/com/orasi/utils/Sleeper.java
+++ b/src/main/java/com/orasi/utils/Sleeper.java
@@ -1,15 +1,19 @@
 package com.orasi.utils;
 
 import org.apache.commons.lang3.time.StopWatch;
+import static com.orasi.utils.Constants.MAX_SLEEP_TIME;
 
 public class Sleeper {
-    public static void sleep(long millis) {
-        TestReporter.logTrace("Sleeping for [ " + millis + " ] milliseconds");
+    public static void sleep(double seconds) {
+    	if (seconds>MAX_SLEEP_TIME) {
+    		throw new RuntimeException("Sleep time exceeds 600 seconds.");
+    	}
+        TestReporter.logTrace("Sleeping for [ " + seconds + " ] seconds");
         StopWatch stopwatch = new StopWatch();
         stopwatch.start();
         do {
 
-        } while (stopwatch.getTime() < millis);
+        } while ((double)(stopwatch.getTime()/1000.0) < seconds);
         stopwatch.stop();
         stopwatch.reset();
     }

--- a/src/main/java/com/orasi/utils/Sleeper.java
+++ b/src/main/java/com/orasi/utils/Sleeper.java
@@ -2,6 +2,7 @@ package com.orasi.utils;
 
 import org.apache.commons.lang3.time.StopWatch;
 import static com.orasi.utils.Constants.MAX_SLEEP_TIME;
+import com.orasi.AutomationException;
 
 public class Sleeper {
     public static void sleep(double seconds) {

--- a/src/main/java/com/orasi/web/debugging/Highlight.java
+++ b/src/main/java/com/orasi/web/debugging/Highlight.java
@@ -54,7 +54,7 @@ public class Highlight {
 
     public static void flashHighlightSuccess(WebDriver driver, WebElement element) {
         highlight(driver, element, jsHighlight, defaultSuccessColor);
-        Sleeper.sleep(500);
+        Sleeper.sleep(0.5);
         highlight(driver, element, jsHighlight, Colors.NONE);
     }
 

--- a/src/test/java/com/orasi/api/soapServices/TestSoapService.java
+++ b/src/test/java/com/orasi/api/soapServices/TestSoapService.java
@@ -498,6 +498,6 @@ public class TestSoapService extends APIBaseTest {
     }
 
     private void sleep() {
-        Sleeper.sleep(1000);
+        Sleeper.sleep(1.0);
     }
 }

--- a/src/test/java/com/orasi/web/TestOrasiDriver.java
+++ b/src/test/java/com/orasi/web/TestOrasiDriver.java
@@ -409,7 +409,7 @@ public class TestOrasiDriver extends WebBaseTest {
     public void executeAsyncJavaScript() {
 
         driver.get("http://cafetownsend-angular-rails.herokuapp.com/login");
-        Sleeper.sleep(3000);
+        Sleeper.sleep(3.0);
         driver.executeAsyncJavaScript(
                 "var callback = arguments[arguments.length - 1];angular.element(document.body).injector().get('$browser').notifyWhenNoOutstandingRequests(callback);");
     }
@@ -453,7 +453,7 @@ public class TestOrasiDriver extends WebBaseTest {
     @Title("findNGRepeater")
     @Test(groups = { "regression", "utils", "orasidriver" }, dependsOnMethods = "findNGController")
     public void findNGRepeater() {
-        Sleeper.sleep(2000);
+        Sleeper.sleep(2.0);
         Assert.assertNotNull(driver.findElement(ByNG.repeater("employee in employees")));
     }
 

--- a/src/test/java/com/orasi/web/webelements/TestLink.java
+++ b/src/test/java/com/orasi/web/webelements/TestLink.java
@@ -100,7 +100,7 @@ public class TestLink extends WebBaseTest {
             throw new SkipException("Test not valid for Internet Explorer");
         }
         Link link = driver.findLink(By.xpath("//a[@href='hiddenLink.html']"));
-        Sleeper.sleep(1000);
+        Sleeper.sleep(1.0);
         driver.findLink(By.xpath("//a[@href='testLinks.html']")).click();
         boolean valid = false;
         try {


### PR DESCRIPTION
Converts Sleeper.sleep and all references to use (double) _seconds_ instead of (long) _milliseconds_. Adds max sleep time constant of **600 seconds**. If the number of seconds is longer than 600, throws a RunTime Exception. 